### PR TITLE
Leave npm bunyan-pretty in the repo for backwards compatability

### DIFF
--- a/.npm/package/npm-shrinkwrap.json
+++ b/.npm/package/npm-shrinkwrap.json
@@ -12,7 +12,7 @@
           }
         },
         "mv": {
-          "version": "2.0.3",
+          "version": "2.1.1",
           "dependencies": {
             "mkdirp": {
               "version": "0.5.1",
@@ -23,10 +23,52 @@
               }
             },
             "ncp": {
-              "version": "0.6.0"
+              "version": "2.0.0"
             },
             "rimraf": {
-              "version": "2.2.8"
+              "version": "2.4.1",
+              "dependencies": {
+                "glob": {
+                  "version": "4.5.3",
+                  "dependencies": {
+                    "inflight": {
+                      "version": "1.0.4",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1"
+                        }
+                      }
+                    },
+                    "inherits": {
+                      "version": "2.0.1"
+                    },
+                    "minimatch": {
+                      "version": "2.0.8",
+                      "dependencies": {
+                        "brace-expansion": {
+                          "version": "1.1.0",
+                          "dependencies": {
+                            "balanced-match": {
+                              "version": "0.2.0"
+                            },
+                            "concat-map": {
+                              "version": "0.0.1"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "once": {
+                      "version": "1.3.2",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
             }
           }
         },

--- a/.npm/package/npm-shrinkwrap.json
+++ b/.npm/package/npm-shrinkwrap.json
@@ -42,6 +42,9 @@
           "version": "2.3.6"
         }
       }
+    },
+    "bunyan-prettystream": {
+      "version": "0.1.3"
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
-Add and export the [Bunyan](https://github.com/trentm/node-bunyan) logging module, also add the browserify client and bunyan-pretty.
+Add and export the [Bunyan](https://github.com/trentm/node-bunyan) logging module, also add the browserify client, bunyan-prettystream, and bunyan-pretty.
 
     `meteor add ongoworks:bunyan-logger`
 
-Adds [bunyan-pretty](https://www.npmjs.com/package/bunyan-pretty) for pretty-printed bunyan Meteor output.
+Adds: [bunyan-prettystream](https://www.npmjs.com/package/bunyan-prettystream) and
+[bunyan-pretty](https://www.npmjs.com/package/bunyan-pretty) for pretty-printed bunyan Meteor output.
 
 ## Server
 
@@ -26,7 +27,7 @@ Example bunyan-pretty implemention in your application as:
 ```
 log = logger.bunyan.createLogger({
   name: 'your-app',
-  stream: process.stdout.isTTY ? logger.bunyanPretty() : process.stdout,
+  stream: process.stdout.isTTY ? new logger.bunyanPrettyStream(process.stdout) : process.stdout,
   level: 'info'
 })
 ```

--- a/README.md
+++ b/README.md
@@ -6,11 +6,14 @@ Adds [bunyan-pretty](https://www.npmjs.com/package/bunyan-pretty) for pretty-pri
 
 ## Server
 
-The package exports `logger.bunyan` and `logger.bunyanPretty`.
+The package exports `logger.bunyan`, `logger.bunyanPrettyStream` and `logger.bunyanPretty`.  
+
+_NOTE: `logger.bunyanPretty` can cause issues when running on Windows_
 
 ```
 logger = {};
 logger.bunyan = Npm.require('bunyan');
+logger.bunyanPrettyStream = Npm.require('bunyan-prettystream')
 logger.bunyanPretty = Npm.require('bunyan-pretty');
 ```
 

--- a/bunyan.js
+++ b/bunyan.js
@@ -1,3 +1,4 @@
 logger = {};
 logger.bunyan = Npm.require('bunyan');
 logger.bunyanPretty = Npm.require('bunyan-pretty');
+logger.bunyanPrettyStream = Npm.require('bunyan-prettystream');

--- a/package.js
+++ b/package.js
@@ -5,7 +5,7 @@ Package.describe({
   git: "https://github.com/ongoworks/meteor-bunyan.git"
 });
 
-Npm.depends({'bunyan': '1.4.0','bunyan-pretty': '0.0.1'});
+Npm.depends({'bunyan': '1.4.0','bunyan-pretty': '0.0.1', 'bunyan-prettystream': '0.1.3'});
 
 Package.onUse(function (api) {
   api.versionsFrom('METEOR@1.0');


### PR DESCRIPTION
In case any apps are currently depending and to avoid a breaking change, we can leave `bunyan-pretty` in the package and just add `bunyan-prettystream` for future compatibility with Windows. 